### PR TITLE
Add custom extensions support

### DIFF
--- a/src/ConsoleHelper.php
+++ b/src/ConsoleHelper.php
@@ -8,16 +8,17 @@ class ConsoleHelper
 {
     protected $converter;
     protected $output;
-
     protected $recursive = false;
     protected $overwrite;
+    protected $extensions;
 
-    public function __construct(OutputInterface $output, $recursive, $overwrite)
+    public function __construct(OutputInterface $output, $recursive, $overwrite, $extensions)
     {
         $this->converter = new Converter();
         $this->output = $output;
         $this->recursive = $recursive;
         $this->overwrite = $overwrite;
+        $this->extensions = $extensions;
     }
 
     public function folderConvert($folderPath)
@@ -101,6 +102,6 @@ class ConsoleHelper
      */
     protected function isConvertableFile($extension)
     {
-        return in_array($extension, ['php', 'html']);
+        return in_array($extension, $this->extensions);
     }
 }

--- a/tailwindo
+++ b/tailwindo
@@ -21,11 +21,11 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
     ->addArgument('arg', InputArgument::OPTIONAL, 'a file path/a folder path/Bootstrap CSS classes')
 
     ->addOption('replace', null, InputOption::VALUE_REQUIRED, 'This will overwrite the original file.', false)
-
+   
     ->addOption('recursive', 'r', InputOption::VALUE_OPTIONAL, 'This will recurse through all directories under the main directory', false)
-     
+    
     ->addOption('extensions', 'e', InputOption::VALUE_REQUIRED, 'This allows for custom extensions', 'php,html')
-     
+
     ->setCode(function (InputInterface $input, OutputInterface $output) {
         // output arguments and options
         $arg = $input->getFirstArgument();
@@ -41,9 +41,13 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
         $replace = (bool) $input->getOption('replace');
 
         $is_recursive = (bool) $input->getOption('recursive');
+        
+        $acceptedExts = array_map('trim', array_map(function ($ext) {
+            return trim($ext, '.');
+        }, array_filter(explode(',', $input->getOption('extensions')), function ($ext) {
+            return !empty($ext);
+        })));
 
-        $acceptedExts = explode(',', $input->getOption('extensions'));
-        die(print_r($acceptedExts,true));
         $consoleHelper = new ConsoleHelper($output, $is_recursive, $replace, $acceptedExts);
 
         //file?

--- a/tailwindo
+++ b/tailwindo
@@ -21,7 +21,10 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
     ->addArgument('arg', InputArgument::OPTIONAL, 'a file path/a folder path/Bootstrap CSS classes')
 
     ->addOption('replace', null, InputOption::VALUE_REQUIRED, 'This will overwrite the original file.', false)
+
     ->addOption('recursive', 'r', InputOption::VALUE_OPTIONAL, 'This will recurse through all directories under the main directory', false)
+     
+    ->addOption('extensions', 'e', InputOption::VALUE_REQUIRED, 'This allows for custom extensions', 'php,html')
      
     ->setCode(function (InputInterface $input, OutputInterface $output) {
         // output arguments and options
@@ -39,8 +42,9 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
 
         $is_recursive = (bool) $input->getOption('recursive');
 
-        $consoleHelper = new ConsoleHelper($output, $is_recursive, $replace);
-
+        $acceptedExts = explode(',', $input->getOption('extensions'));
+        die(print_r($acceptedExts,true));
+        $consoleHelper = new ConsoleHelper($output, $is_recursive, $replace, $acceptedExts);
 
         //file?
         if (is_file($arg)) {


### PR DESCRIPTION
# Changes
 - Adds the ability to add custom file extensions to the search for files with the flags `--extentions=php,html` or `-e php,html`

Closes https://github.com/awssat/tailwindo/issues/5