### PR TITLE
Add a link to composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note: Tailwindo currently convert code to Tailwindcss 0.7, to convert to 0.1 fro
 
 ## Installing `tailwindo` for CLI use
 
-You can install the package via composer globally:
+You can install the package via [composer](https://getcomposer.org/doc/00-intro.md) globally:
 
 `$ composer global require awssat/tailwindo`
 


### PR DESCRIPTION
I'm not familiar with the package management system in PHP, so I had to google around for a while to figure out I just needed to `brew install composer`. This commit links the word `composer` in the README to composer's installation instructions.