### PR TITLE
fix text with media breakpoints

### DIFF
--- a/src/ConsoleHelper.php
+++ b/src/ConsoleHelper.php
@@ -36,10 +36,9 @@ class ConsoleHelper
 
         $this->output->writeln('<fg=black;bg=blue>Converting Folder'.($this->components ? ' (extracted to tailwindo-components.css)' : '').':</> '.realpath($folderPath));
         $this->output->writeln(
-                        '<fg=black;bg=green>Converting from</> '.$this->converter->getFramework()->frameworkName().' '.
-                        $frameworkVersion . ' <fg=black;bg=green> to </> Tailwind '. $TailwindVersion
-                    );
-
+            '<fg=black;bg=green>Converting from</> '.$this->converter->getFramework()->frameworkName().' '.
+                        $frameworkVersion.' <fg=black;bg=green> to </> Tailwind '.$TailwindVersion
+        );
 
         if ($this->recursive) {
             $iterator = new \RecursiveIteratorIterator(
@@ -78,7 +77,7 @@ class ConsoleHelper
             [$frameworkVersion, $TailwindVersion] = $this->converter->getFramework()->supportedVersion();
             $this->output->writeln(
                 '<fg=black;bg=green>Converting from</> '.$this->converter->getFramework()->frameworkName().' '.
-                $frameworkVersion . ' <fg=black;bg=green> to </> Tailwind '. $TailwindVersion .PHP_EOL
+                $frameworkVersion.' <fg=black;bg=green> to </> Tailwind '.$TailwindVersion.PHP_EOL
             );
         }
 

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -104,10 +104,10 @@ class Converter
 
         $result = '';
         foreach ($this->components as $selector => $classes) {
-            if($selector == $classes) {
+            if ($selector == $classes) {
                 continue;
             }
-    
+
             $result .= ".{$selector} {\n\t@apply {$classes};\n}\n";
         }
 

--- a/src/Framework/BootstrapFramework.php
+++ b/src/Framework/BootstrapFramework.php
@@ -428,11 +428,10 @@ class BootstrapFramework implements Framework
             'font-italic'        => 'italic',
         ];
 
-        foreach (array_merge($this->mediaOptions, [''=>'']) as $btMedia => $twMedia) {
-            $items['text'.(empty($btMedia) ? '' : '-').'-'.$btMedia.'-left'] = (empty($twMedia) ? '' : $twMedia.':').'text-left';
-            $items['text'.(empty($btMedia) ? '' : '-').'-'.$btMedia.'-right'] = (empty($twMedia) ? '' : $twMedia.':').'text-right';
-            $items['text'.(empty($btMedia) ? '' : '-').'-'.$btMedia.'-center'] = (empty($twMedia) ? '' : $twMedia.':').'text-center';
-            $items['text'.(empty($btMedia) ? '' : '-').'-'.$btMedia.'-justify'] = (empty($twMedia) ? '' : $twMedia.':').'text-justify';
+        foreach (['left', 'right', 'center', 'justify'] as $alignment) {
+            foreach (array_merge($this->mediaOptions, [''=>'']) as $btMedia => $twMedia) {
+                $items['text'.(empty($btMedia) ? '' : '-'.$btMedia).'-'.$alignment] = (empty($twMedia) ? '' : $twMedia.':').'text-'.$alignment;
+            }
         }
 
         return $items;

--- a/src/Framework/BootstrapFramework.php
+++ b/src/Framework/BootstrapFramework.php
@@ -340,7 +340,9 @@ class BootstrapFramework implements Framework
 
             $items['flex'.(empty($btMedia) ? '' : '-').$btMedia.'-nowrap'] = (empty($twMedia) ? '' : $twMedia.':').'flex-no-wrap';
 
-            $items['order-'.$btMedia.'-{regex_number}'] = $twMedia.':order-{regex_number}';
+            if ($btMedia != '') {
+                $items['order-'.$btMedia.'-{regex_number}'] = $twMedia.':order-{regex_number}';
+            }
         }
 
         return $items;

--- a/tests/Bootstrap/BootstrapFrameworkTest.php
+++ b/tests/Bootstrap/BootstrapFrameworkTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Awssat\Tailwindo\Test;
+
+use PHPUnit\Framework\TestCase;
+use Awssat\Tailwindo\Framework\BootstrapFramework;
+use Awssat\Tailwindo\Converter;
+
+class FrameworkTest extends TestCase
+{
+    /** @var Awssat\Tailwindo\Converter */
+    protected $bootstrap;
+    protected $converter;
+
+    protected function setUp(): void
+    {
+        $this->bootstrap = (new BootstrapFramework())->get();
+        $this->converter = (new Converter())->setFramework('bootstrap');
+    }
+
+    /** @test */
+    public function it_searches_for_no_classes_containing_double_dashes()
+    {
+        $match_array = [];
+
+        foreach ($this->bootstrap as $item) {
+            foreach ($item as $search => $replace) {
+                if (strpos($search, '--') !== false) {
+                    array_push($match_array, $search);
+                }
+            }
+        }
+
+        // print_r($match_array);
+        $this->assertEmpty($match_array);
+    }
+
+    /** @test */
+    public function it_replaces_with_no_classes_containing_double_dashes()
+    {
+        $match_array = [];
+
+        foreach ($this->bootstrap as $item) {
+            foreach ($item as $search => $replace) {
+                if ($replace instanceof \Closure) {
+                    $callableReplace = \Closure::bind($replace, $this->converter, Converter::class);
+                    $replace = $callableReplace();
+                }
+
+                if (strpos($replace, '--') !== false) {
+                    array_push($match_array, [$search => $replace]);
+                }
+            }
+        }
+
+        // print_r($match_array);
+        $this->assertEmpty($match_array);
+    }
+}

--- a/tests/Bootstrap/BootstrapFrameworkTest.php
+++ b/tests/Bootstrap/BootstrapFrameworkTest.php
@@ -31,7 +31,7 @@ class FrameworkTest extends TestCase
             }
         }
 
-        // print_r($match_array);
+        print_r($match_array);
         $this->assertEmpty($match_array);
     }
 

--- a/tests/Bootstrap/BootstrapFrameworkTest.php
+++ b/tests/Bootstrap/BootstrapFrameworkTest.php
@@ -2,11 +2,11 @@
 
 namespace Awssat\Tailwindo\Test;
 
-use PHPUnit\Framework\TestCase;
-use Awssat\Tailwindo\Framework\BootstrapFramework;
 use Awssat\Tailwindo\Converter;
+use Awssat\Tailwindo\Framework\BootstrapFramework;
+use PHPUnit\Framework\TestCase;
 
-class FrameworkTest extends TestCase
+class BootstrapFrameworkTest extends TestCase
 {
     /** @var Awssat\Tailwindo\Converter */
     protected $bootstrap;

--- a/tests/Bootstrap/TextTest.php
+++ b/tests/Bootstrap/TextTest.php
@@ -27,5 +27,4 @@ class TextTest extends TestCase
             $this->converter->classesOnly(true)->setContent('text-lg-justify')->convert()->get()
         );
     }
-
 }

--- a/tests/Bootstrap/TextTest.php
+++ b/tests/Bootstrap/TextTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Awssat\Tailwindo\Test;
+
+use Awssat\Tailwindo\Converter;
+use PHPUnit\Framework\TestCase;
+
+class TextTest extends TestCase
+{
+    /** @var Awssat\Tailwindo\Converter */
+    protected $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = (new Converter())->setFramework('bootstrap');
+    }
+
+    /** @test */
+    public function it_converts_text_with_breakpoint()
+    {
+        $this->assertEquals(
+            'sm:text-left',
+            $this->converter->classesOnly(true)->setContent('text-xs-left')->convert()->get()
+        );
+        $this->assertEquals(
+            'lg:text-justify',
+            $this->converter->classesOnly(true)->setContent('text-lg-justify')->convert()->get()
+        );
+    }
+
+}


### PR DESCRIPTION
**The problem:**

`tailwindo 'text-md-right'` results in `Converted Code: 'text-md-right'` when  `Converted Code: 'md:text-right'` was expected.

**What I have done to fix it:**

- Remove an extra dash that caused the program to look for `text--md-right`
- Loop through `['left', 'right', 'center', 'justify'] as $alignment` to avoid code duplication
- Add tests.