### PR TITLE
Feature/fix spacings (add more accurate and tested conversion of margin/padding)

### DIFF
--- a/src/ConsoleHelper.php
+++ b/src/ConsoleHelper.php
@@ -36,10 +36,9 @@ class ConsoleHelper
 
         $this->output->writeln('<fg=black;bg=blue>Converting Folder'.($this->components ? ' (extracted to tailwindo-components.css)' : '').':</> '.realpath($folderPath));
         $this->output->writeln(
-                        '<fg=black;bg=green>Converting from</> '.$this->converter->getFramework()->frameworkName().' '.
-                        $frameworkVersion . ' <fg=black;bg=green> to </> Tailwind '. $TailwindVersion
-                    );
-
+            '<fg=black;bg=green>Converting from</> '.$this->converter->getFramework()->frameworkName().' '.
+                        $frameworkVersion.' <fg=black;bg=green> to </> Tailwind '.$TailwindVersion
+        );
 
         if ($this->recursive) {
             $iterator = new \RecursiveIteratorIterator(
@@ -78,7 +77,7 @@ class ConsoleHelper
             [$frameworkVersion, $TailwindVersion] = $this->converter->getFramework()->supportedVersion();
             $this->output->writeln(
                 '<fg=black;bg=green>Converting from</> '.$this->converter->getFramework()->frameworkName().' '.
-                $frameworkVersion . ' <fg=black;bg=green> to </> Tailwind '. $TailwindVersion .PHP_EOL
+                $frameworkVersion.' <fg=black;bg=green> to </> Tailwind '.$TailwindVersion.PHP_EOL
             );
         }
 

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -104,10 +104,10 @@ class Converter
 
         $result = '';
         foreach ($this->components as $selector => $classes) {
-            if($selector == $classes) {
+            if ($selector == $classes) {
                 continue;
             }
-    
+
             $result .= ".{$selector} {\n\t@apply {$classes};\n}\n";
         }
 

--- a/src/Framework/BootstrapFramework.php
+++ b/src/Framework/BootstrapFramework.php
@@ -386,8 +386,8 @@ class BootstrapFramework implements Framework
 
         foreach ($spacingProperties as $property) {
             foreach ($this->spacings as $btSpacing => $twSpacing) {
-                  $items[$property.'-'.$btSpacing] = $property.'-'.$twSpacing;
-              }
+                $items[$property.'-'.$btSpacing] = $property.'-'.$twSpacing;
+            }
         }
 
         foreach ($spacingProperties as $property) {
@@ -397,9 +397,9 @@ class BootstrapFramework implements Framework
                     $items[$property.'{regex_string}-'.$btMedia.'-'.$btSpacing] = $twMedia.':'.$property.'{regex_string}-'.$twSpacing;
                 }
 
-              $items[$property.'{regex_string}-'.$btMedia.'-auto'] = $twMedia.':'.$property.'{regex_string}-auto';
-          }
-      }
+                $items[$property.'{regex_string}-'.$btMedia.'-auto'] = $twMedia.':'.$property.'{regex_string}-auto';
+            }
+        }
 
         return $items;
     }

--- a/src/Framework/BootstrapFramework.php
+++ b/src/Framework/BootstrapFramework.php
@@ -13,6 +13,15 @@ class BootstrapFramework implements Framework
         'print' => 'print',
     ];
 
+    protected $spacings = [
+        '0'  => '0',
+        '1'  => '1',
+        '2'  => '2',
+        '3'  => '4',
+        '4'  => '6',
+        '5'  => '12',
+    ];
+
     protected $grid = [
         '1'  => '1/6',
         '2'  => '1/5',
@@ -373,22 +382,24 @@ class BootstrapFramework implements Framework
     protected function spacing(): array
     {
         $items = [];
-        foreach (range(1, 5) as $spacing) {
-            $items['p-'.$spacing] = 'p-'.($spacing == 5 ? 7 : $spacing + 2);
-            $items['m-'.$spacing] = 'm-'.($spacing == 5 ? 7 : $spacing + 2);
+        $spacingProperties = ['p', 'm'];
+
+        foreach ($spacingProperties as $property) {
+          foreach ($this->spacings as $btSpacing => $twSpacing) {
+                $items[$property.'-'.$btSpacing] = $property.'-'.$twSpacing;
+            }
         }
 
-        foreach ($this->mediaOptions as $btMedia => $twMedia) {
-            foreach (range(1, 5) as $spacing) {
-                $items['p-'.$btMedia.'-'.$spacing] = $twMedia.':p-'.($spacing == 5 ? 7 : $spacing + 2);
-                $items['m-'.$btMedia.'-'.$spacing] = $twMedia.':m-'.($spacing == 5 ? 7 : $spacing + 2);
-                $items['m{regex_string}-'.$btMedia.'-'.$spacing] = $twMedia.':m{regex_string}-'.($spacing == 5 ? 7 : $spacing + 2);
-                $items['p{regex_string}-'.$btMedia.'-'.$spacing] = $twMedia.':p{regex_string}-'.($spacing == 5 ? 7 : $spacing + 2);
+        foreach ($spacingProperties as $property) {
+          foreach ($this->mediaOptions as $btMedia => $twMedia) {
+            foreach ($this->spacings as $btSpacing => $twSpacing) {
+                $items[$property.'-'.$btMedia.'-'.$btSpacing] = $twMedia.':'.$property.'-'.$twSpacing;
+                $items[$property.'{regex_string}-'.$btMedia.'-'.$btSpacing] = $twMedia.':'.$property.'{regex_string}-'.$twSpacing;
             }
 
-            $items['p{regex_string}-'.$btMedia.'-auto'] = $twMedia.':p{regex_string}-auto';
-            $items['m{regex_string}-'.$btMedia.'-auto'] = $twMedia.':m{regex_string}-auto';
+            $items[$property.'{regex_string}-'.$btMedia.'-auto'] = $twMedia.':'.$property.'{regex_string}-auto';
         }
+      }
 
         return $items;
     }

--- a/src/Framework/BootstrapFramework.php
+++ b/src/Framework/BootstrapFramework.php
@@ -385,20 +385,20 @@ class BootstrapFramework implements Framework
         $spacingProperties = ['p', 'm'];
 
         foreach ($spacingProperties as $property) {
-          foreach ($this->spacings as $btSpacing => $twSpacing) {
-                $items[$property.'-'.$btSpacing] = $property.'-'.$twSpacing;
-            }
+            foreach ($this->spacings as $btSpacing => $twSpacing) {
+                  $items[$property.'-'.$btSpacing] = $property.'-'.$twSpacing;
+              }
         }
 
         foreach ($spacingProperties as $property) {
-          foreach ($this->mediaOptions as $btMedia => $twMedia) {
-            foreach ($this->spacings as $btSpacing => $twSpacing) {
-                $items[$property.'-'.$btMedia.'-'.$btSpacing] = $twMedia.':'.$property.'-'.$twSpacing;
-                $items[$property.'{regex_string}-'.$btMedia.'-'.$btSpacing] = $twMedia.':'.$property.'{regex_string}-'.$twSpacing;
-            }
+            foreach ($this->mediaOptions as $btMedia => $twMedia) {
+                foreach ($this->spacings as $btSpacing => $twSpacing) {
+                    $items[$property.'-'.$btMedia.'-'.$btSpacing] = $twMedia.':'.$property.'-'.$twSpacing;
+                    $items[$property.'{regex_string}-'.$btMedia.'-'.$btSpacing] = $twMedia.':'.$property.'{regex_string}-'.$twSpacing;
+                }
 
-            $items[$property.'{regex_string}-'.$btMedia.'-auto'] = $twMedia.':'.$property.'{regex_string}-auto';
-        }
+              $items[$property.'{regex_string}-'.$btMedia.'-auto'] = $twMedia.':'.$property.'{regex_string}-auto';
+          }
       }
 
         return $items;

--- a/tests/Bootstrap/ConverterTest.php
+++ b/tests/Bootstrap/ConverterTest.php
@@ -16,7 +16,7 @@ class ConverterTest extends TestCase
     }
 
     /** @test */
-    public function it_return_output()
+    public function it_returns_output()
     {
         $this->assertEquals(
             'sm:flex',
@@ -27,4 +27,5 @@ class ConverterTest extends TestCase
             $this->converter->setContent('<a class="text-muted">love</a>')->convert()->get()
         );
     }
+
 }

--- a/tests/Bootstrap/ConverterTest.php
+++ b/tests/Bootstrap/ConverterTest.php
@@ -27,5 +27,4 @@ class ConverterTest extends TestCase
             $this->converter->setContent('<a class="text-muted">love</a>')->convert()->get()
         );
     }
-
 }

--- a/tests/Bootstrap/SpacingTest.php
+++ b/tests/Bootstrap/SpacingTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Awssat\Tailwindo\Test;
+
+use Awssat\Tailwindo\Converter;
+use PHPUnit\Framework\TestCase;
+
+class SpacingTest extends TestCase
+{
+    /** @var Awssat\Tailwindo\Converter */
+    protected $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = (new Converter())->setFramework('bootstrap');
+    }
+
+
+    // https://getbootstrap.com/docs/4.0/utilities/spacing/
+    // https://tailwindcss.com/docs/padding/
+
+    /**
+     * @group Padding
+     */
+    /** @test */
+    public function padding_it_converts_on_all_sides()
+    {
+        $this->assertEquals(
+            'p-1',
+            $this->converter->classesOnly(true)->setContent('p-1')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'sm:p-1',
+            $this->converter->classesOnly(true)->setContent('p-sm-1')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'md:p-2',
+            $this->converter->classesOnly(true)->setContent('p-md-2')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'lg:p-4',
+            $this->converter->classesOnly(true)->setContent('p-lg-3')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'xl:p-6',
+            $this->converter->classesOnly(true)->setContent('p-xl-4')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'xl:p-12',
+            $this->converter->classesOnly(true)->setContent('p-xl-5')->convert()->get()
+        );
+    }
+
+
+    /** @test */
+    public function padding_it_converts_on_y()
+    {
+        $this->assertEquals(
+            'py-1',
+            $this->converter->classesOnly(true)->setContent('py-1')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'sm:py-1',
+            $this->converter->classesOnly(true)->setContent('py-sm-1')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'md:py-2',
+            $this->converter->classesOnly(true)->setContent('py-md-2')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'lg:py-4',
+            $this->converter->classesOnly(true)->setContent('py-lg-3')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'xl:py-6',
+            $this->converter->classesOnly(true)->setContent('py-xl-4')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'xl:py-12',
+            $this->converter->classesOnly(true)->setContent('py-xl-5')->convert()->get()
+        );
+    }
+
+    /** @test */
+    public function padding_it_converts_on_x()
+    {
+        $this->assertEquals(
+            'px-1',
+            $this->converter->classesOnly(true)->setContent('px-1')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'sm:px-1',
+            $this->converter->classesOnly(true)->setContent('px-sm-1')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'md:px-2',
+            $this->converter->classesOnly(true)->setContent('px-md-2')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'lg:px-4',
+            $this->converter->classesOnly(true)->setContent('px-lg-3')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'xl:px-6',
+            $this->converter->classesOnly(true)->setContent('px-xl-4')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'xl:px-12',
+            $this->converter->classesOnly(true)->setContent('px-xl-5')->convert()->get()
+        );
+    }
+
+    /** @test */
+    public function padding_it_converts_0_on_all_sides()
+    {
+        $this->assertEquals(
+            'p-0',
+            $this->converter->classesOnly(true)->setContent('p-0')->convert()->get()
+        );
+
+        $this->assertEquals(
+            'lg:py-0',
+            $this->converter->classesOnly(true)->setContent('py-lg-0')->convert()->get()
+        );
+    }
+
+    /**
+     * @group Margin
+     */
+
+     /** @test */
+     public function margin_it_converts_on_all_sides()
+     {
+         $this->assertEquals(
+             'm-1',
+             $this->converter->classesOnly(true)->setContent('m-1')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'sm:m-1',
+             $this->converter->classesOnly(true)->setContent('m-sm-1')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'md:m-2',
+             $this->converter->classesOnly(true)->setContent('m-md-2')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'lg:m-4',
+             $this->converter->classesOnly(true)->setContent('m-lg-3')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'xl:m-6',
+             $this->converter->classesOnly(true)->setContent('m-xl-4')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'xl:m-12',
+             $this->converter->classesOnly(true)->setContent('m-xl-5')->convert()->get()
+         );
+     }
+
+
+     /** @test */
+     public function margin_it_converts_on_y()
+     {
+         $this->assertEquals(
+             'my-1',
+             $this->converter->classesOnly(true)->setContent('my-1')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'sm:my-1',
+             $this->converter->classesOnly(true)->setContent('my-sm-1')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'md:my-2',
+             $this->converter->classesOnly(true)->setContent('my-md-2')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'lg:my-4',
+             $this->converter->classesOnly(true)->setContent('my-lg-3')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'xl:my-6',
+             $this->converter->classesOnly(true)->setContent('my-xl-4')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'xl:my-12',
+             $this->converter->classesOnly(true)->setContent('my-xl-5')->convert()->get()
+         );
+     }
+
+     /** @test */
+     public function margin_it_converts_on_x()
+     {
+         $this->assertEquals(
+             'mx-1',
+             $this->converter->classesOnly(true)->setContent('mx-1')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'sm:mx-1',
+             $this->converter->classesOnly(true)->setContent('mx-sm-1')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'md:mx-2',
+             $this->converter->classesOnly(true)->setContent('mx-md-2')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'lg:mx-4',
+             $this->converter->classesOnly(true)->setContent('mx-lg-3')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'xl:mx-6',
+             $this->converter->classesOnly(true)->setContent('mx-xl-4')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'xl:mx-12',
+             $this->converter->classesOnly(true)->setContent('mx-xl-5')->convert()->get()
+         );
+     }
+
+     /** @test */
+     public function margin_it_converts_0_on_all_sides()
+     {
+         $this->assertEquals(
+             'm-0',
+             $this->converter->classesOnly(true)->setContent('m-0')->convert()->get()
+         );
+
+         $this->assertEquals(
+             'lg:my-0',
+             $this->converter->classesOnly(true)->setContent('my-lg-0')->convert()->get()
+         );
+     }
+
+}

--- a/tests/Bootstrap/SpacingTest.php
+++ b/tests/Bootstrap/SpacingTest.php
@@ -15,13 +15,13 @@ class SpacingTest extends TestCase
         $this->converter = (new Converter())->setFramework('bootstrap');
     }
 
-
     // https://getbootstrap.com/docs/4.0/utilities/spacing/
     // https://tailwindcss.com/docs/padding/
 
     /**
-    * @group Padding
-    */
+     * @group Padding
+     */
+
     /** @test */
     public function padding_it_converts_on_all_sides()
     {
@@ -55,7 +55,6 @@ class SpacingTest extends TestCase
             $this->converter->classesOnly(true)->setContent('p-xl-5')->convert()->get()
         );
     }
-
 
     /** @test */
     public function padding_it_converts_on_y()
@@ -140,8 +139,8 @@ class SpacingTest extends TestCase
     }
 
     /**
-    * @group Margin
-    */
+     * @group Margin
+     */
 
     /** @test */
     public function margin_it_converts_on_all_sides()
@@ -176,7 +175,6 @@ class SpacingTest extends TestCase
             $this->converter->classesOnly(true)->setContent('m-xl-5')->convert()->get()
         );
     }
-
 
     /** @test */
     public function margin_it_converts_on_y()
@@ -259,5 +257,4 @@ class SpacingTest extends TestCase
             $this->converter->classesOnly(true)->setContent('my-lg-0')->convert()->get()
         );
     }
-
 }

--- a/tests/Bootstrap/SpacingTest.php
+++ b/tests/Bootstrap/SpacingTest.php
@@ -20,8 +20,8 @@ class SpacingTest extends TestCase
     // https://tailwindcss.com/docs/padding/
 
     /**
-     * @group Padding
-     */
+    * @group Padding
+    */
     /** @test */
     public function padding_it_converts_on_all_sides()
     {
@@ -140,124 +140,124 @@ class SpacingTest extends TestCase
     }
 
     /**
-     * @group Margin
-     */
+    * @group Margin
+    */
 
-     /** @test */
-     public function margin_it_converts_on_all_sides()
-     {
-         $this->assertEquals(
-             'm-1',
-             $this->converter->classesOnly(true)->setContent('m-1')->convert()->get()
-         );
+    /** @test */
+    public function margin_it_converts_on_all_sides()
+    {
+        $this->assertEquals(
+            'm-1',
+            $this->converter->classesOnly(true)->setContent('m-1')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'sm:m-1',
-             $this->converter->classesOnly(true)->setContent('m-sm-1')->convert()->get()
-         );
+        $this->assertEquals(
+            'sm:m-1',
+            $this->converter->classesOnly(true)->setContent('m-sm-1')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'md:m-2',
-             $this->converter->classesOnly(true)->setContent('m-md-2')->convert()->get()
-         );
+        $this->assertEquals(
+            'md:m-2',
+            $this->converter->classesOnly(true)->setContent('m-md-2')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'lg:m-4',
-             $this->converter->classesOnly(true)->setContent('m-lg-3')->convert()->get()
-         );
+        $this->assertEquals(
+            'lg:m-4',
+            $this->converter->classesOnly(true)->setContent('m-lg-3')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'xl:m-6',
-             $this->converter->classesOnly(true)->setContent('m-xl-4')->convert()->get()
-         );
+        $this->assertEquals(
+            'xl:m-6',
+            $this->converter->classesOnly(true)->setContent('m-xl-4')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'xl:m-12',
-             $this->converter->classesOnly(true)->setContent('m-xl-5')->convert()->get()
-         );
-     }
+        $this->assertEquals(
+            'xl:m-12',
+            $this->converter->classesOnly(true)->setContent('m-xl-5')->convert()->get()
+        );
+    }
 
 
-     /** @test */
-     public function margin_it_converts_on_y()
-     {
-         $this->assertEquals(
-             'my-1',
-             $this->converter->classesOnly(true)->setContent('my-1')->convert()->get()
-         );
+    /** @test */
+    public function margin_it_converts_on_y()
+    {
+        $this->assertEquals(
+            'my-1',
+            $this->converter->classesOnly(true)->setContent('my-1')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'sm:my-1',
-             $this->converter->classesOnly(true)->setContent('my-sm-1')->convert()->get()
-         );
+        $this->assertEquals(
+            'sm:my-1',
+            $this->converter->classesOnly(true)->setContent('my-sm-1')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'md:my-2',
-             $this->converter->classesOnly(true)->setContent('my-md-2')->convert()->get()
-         );
+        $this->assertEquals(
+            'md:my-2',
+            $this->converter->classesOnly(true)->setContent('my-md-2')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'lg:my-4',
-             $this->converter->classesOnly(true)->setContent('my-lg-3')->convert()->get()
-         );
+        $this->assertEquals(
+            'lg:my-4',
+            $this->converter->classesOnly(true)->setContent('my-lg-3')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'xl:my-6',
-             $this->converter->classesOnly(true)->setContent('my-xl-4')->convert()->get()
-         );
+        $this->assertEquals(
+            'xl:my-6',
+            $this->converter->classesOnly(true)->setContent('my-xl-4')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'xl:my-12',
-             $this->converter->classesOnly(true)->setContent('my-xl-5')->convert()->get()
-         );
-     }
+        $this->assertEquals(
+            'xl:my-12',
+            $this->converter->classesOnly(true)->setContent('my-xl-5')->convert()->get()
+        );
+    }
 
-     /** @test */
-     public function margin_it_converts_on_x()
-     {
-         $this->assertEquals(
-             'mx-1',
-             $this->converter->classesOnly(true)->setContent('mx-1')->convert()->get()
-         );
+    /** @test */
+    public function margin_it_converts_on_x()
+    {
+        $this->assertEquals(
+            'mx-1',
+            $this->converter->classesOnly(true)->setContent('mx-1')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'sm:mx-1',
-             $this->converter->classesOnly(true)->setContent('mx-sm-1')->convert()->get()
-         );
+        $this->assertEquals(
+            'sm:mx-1',
+            $this->converter->classesOnly(true)->setContent('mx-sm-1')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'md:mx-2',
-             $this->converter->classesOnly(true)->setContent('mx-md-2')->convert()->get()
-         );
+        $this->assertEquals(
+            'md:mx-2',
+            $this->converter->classesOnly(true)->setContent('mx-md-2')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'lg:mx-4',
-             $this->converter->classesOnly(true)->setContent('mx-lg-3')->convert()->get()
-         );
+        $this->assertEquals(
+            'lg:mx-4',
+            $this->converter->classesOnly(true)->setContent('mx-lg-3')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'xl:mx-6',
-             $this->converter->classesOnly(true)->setContent('mx-xl-4')->convert()->get()
-         );
+        $this->assertEquals(
+            'xl:mx-6',
+            $this->converter->classesOnly(true)->setContent('mx-xl-4')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'xl:mx-12',
-             $this->converter->classesOnly(true)->setContent('mx-xl-5')->convert()->get()
-         );
-     }
+        $this->assertEquals(
+            'xl:mx-12',
+            $this->converter->classesOnly(true)->setContent('mx-xl-5')->convert()->get()
+        );
+    }
 
-     /** @test */
-     public function margin_it_converts_0_on_all_sides()
-     {
-         $this->assertEquals(
-             'm-0',
-             $this->converter->classesOnly(true)->setContent('m-0')->convert()->get()
-         );
+    /** @test */
+    public function margin_it_converts_0_on_all_sides()
+    {
+        $this->assertEquals(
+            'm-0',
+            $this->converter->classesOnly(true)->setContent('m-0')->convert()->get()
+        );
 
-         $this->assertEquals(
-             'lg:my-0',
-             $this->converter->classesOnly(true)->setContent('my-lg-0')->convert()->get()
-         );
-     }
+        $this->assertEquals(
+            'lg:my-0',
+            $this->converter->classesOnly(true)->setContent('my-lg-0')->convert()->get()
+        );
+    }
 
 }


### PR DESCRIPTION
Sorry for opening another pull request, I mistakenly sent my first one from my master branch, thinking it would be my only contribution.

**Original message:**

Hey there! First of all, thank you for writing this tool!

Let me also preface this by mentioning that I am just starting out with tailwind, so excuse me if I'm fixing something that's not actually broken.

**The problem:**

When I converted my bootstrap project to tailwind, I noticed that 
`tailwindo 'py-lg-0'` returned `Converted Code: 'lg:py-2'`. This didn't seem correct, `'lg:py-0'` was expected.

I was tempted to just open an issue but then curiosity got the better of me and I tried fixing it myself.

**What I have done to fix it:**

- Since bootstrap's spacing steps are a little awkward to code arithmetically, I went with a new `$spacings` array.
- I also combined the string generation for padding and margin by looping through `$spacingProperties = ['p', 'm'];`
- My code is backed up with (probably too many?) tests inside a new Bootstrap folder, so it's easier for you to check the results.

Hope this helps 🙂