### PR TITLE
Add `sr-only` for screenreaders

### DIFF
--- a/src/Framework/BootstrapFramework.php
+++ b/src/Framework/BootstrapFramework.php
@@ -149,7 +149,7 @@ class BootstrapFramework implements Framework
             'text-hide' => '',
 
             // http://getbootstrap.com/docs/4.0/utilities/screenreaders/
-            // 'sr-only'           => 'sr-only',
+            'sr-only'           => 'sr-only',
             'sr-only-focusable' => 'focus:not-sr-only',
 
             // http://getbootstrap.com/docs/4.0/content/images/


### PR DESCRIPTION
fixes #26 

Tailwindcss and Bootstrap have the same usage of this class so we should keep it during conversion.

Bootstrap's Mixin: https://github.com/twbs/bootstrap/blob/main/scss/mixins/_screen-reader.scss
```
  position: absolute;
  width: 1px;
  height: 1px;
  padding: 0;
  margin: -1px; 
  overflow: hidden;
  clip: rect(0, 0, 0, 0);
  white-space: nowrap;
  border: 0;
```

Tailwind: https://tailwindcss.com/docs/screen-readers/
```
position: absolute;
width: 1px;
height: 1px;
padding: 0;
margin: -1px;
overflow: hidden;
clip: rect(0, 0, 0, 0);
white-space: nowrap;
border-width: 0;
```