### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 
     "require": {
         "php": "^7.2|^8.0",
-        "symfony/console": "^4.0|^5.0"
+        "symfony/console": "^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8"


### PR DESCRIPTION
Fix symphony compatibility issue.

Your requirements could not be resolved to an installable set of packages.
```
  Problem 1
    - awssat/tailwindo[3.0.0, ..., 3.0.4] require php ^7.2.0 -> your php version (8.1.5) does not satisfy that requirement.
    - awssat/tailwindo[3.0.5, ..., 3.0.6] require symfony/console ^4.0|^5.0 -> found symfony/console[v4.0.0, ..., v4.4.49, v5.0.0, ..., v5.4.16] but the package is fixed to v6.1.7 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - Root composer.json requires awssat/tailwindo ^3.0 -> satisfiable by awssat/tailwindo[3.0.0, ..., 3.0.6].
   ```